### PR TITLE
Removed erroneous entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # 2021 New Grad Applications
-The 2021 Full time grind has begun! Use this repo to share and keep track of any full time positions in quant, SWE, and PM. 
+
+The 2021 Full time grind has begun! Use this repo to share and keep track of any full time positions in quant, SWE, and PM.  
 
 Looking for internships? Check out our **internship repo** [here](https://github.com/Pitt-CSC/Summer2021-Internships).
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,10 @@ Need interview prep? Check out Yangshun Tay's [Tech Interview Handbook](https://
 |[Akuna Capital](https://akunacapital.com/job-details?gh_jid=2236978&gh_src=fcb01e3f1us) | Chicago, IL | Junior Developer (Software)|
 |[Blend](https://blend.com/company/careers/opening/?oid=ecccb3f7-d3d7-41fb-b2fb-32352c578813)| San Francisco | Software Engineer|
 |[Bridgewater Associates](https://boards.greenhouse.io/bridgewater89/jobs/4076429002)| Westport, CT | Investment Logic Engineer |
-|[Cloudera](https://cloudera.wd5.myworkdayjobs.com/en-US/External_Career/job/USA--California--Palo-Alto/Associate-Software-Engineer---Machine-Learning-Engineering_192243?source=APPLICANT_SOURCE-3-187) | Palo Alto| |
-|[Databrick](https://databricks.com/company/careers/open-positions/job?gh_jid=4743534002&gh_src=62a881d62) | San Francisco, CA | |
 |[D.E. Shaw](https://www.deshaw.com/careers/software-developer-new-york-2646)| New York, NY | Software Developer |
 |[Facebook](https://www.facebook.com/careers/jobs/?q=university%20grad)| Los Angeles, Menlo Park, Seattle, Washington DC, Boston, New York, other locations | Software, Network, Quant Research, Research Engineer |
 |[Jane Street](https://www.janestreet.com/join-jane-street/position/4743431002/) | New York | Software Engineer|
 |[IMC](https://careers.imc.com/us/en/c/graduates-jobs) | Chicago, Sydney, Amsterdam | Software, Hardware, Quant Trader|
 |[Optiver](https://www.optiver.com/na/en/job-opportunities/us-4200121002?foo=bar)| Chicago, Illinois | Software Engineer |
-|[Palantir](https://jobs.lever.co/palantir/01dab70c-073c-4a22-bf76-fb6b9e0a75b0)| Palo Alto, CA | Software Engineer|
 |[Roblox](https://corp.roblox.com/careers/listing/?gh_jid=1777652)| San Mateo, CA | |
 |[Whisper.ai](https://boards.greenhouse.io/whisperai/jobs/4465259002?gh_src=3202a8272)| San Francisco | |
-
-


### PR DESCRIPTION
Cloudera and Palantir links 404, postings must have been taken down
The Databrick link takes you to a 2020 position, not 2021